### PR TITLE
Changed scalikejdbc dependencies compile to provided

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -3,7 +3,8 @@ import sbt._, Keys._
 object ScalikeJDBCPlaySupportProjects extends Build {
 
   lazy val scalikejdbcVersion = "2.2.0"
-  lazy val _version = "2.3.4"
+  lazy val latestScalikejdbcVersion = "2.2.+"
+  lazy val _version = "2.3.5-SNAPSHOT"
 
   // published dependency version
   lazy val _defaultPlayVersion = play.core.PlayVersion.current
@@ -48,8 +49,8 @@ object ScalikeJDBCPlaySupportProjects extends Build {
     baseSettings ++ Seq(
       name := "scalikejdbc-play-plugin",
       libraryDependencies ++= Seq(
-        "org.scalikejdbc"   %% "scalikejdbc"               % scalikejdbcVersion  % "compile",
-        "org.scalikejdbc"   %% "scalikejdbc-config"        % scalikejdbcVersion  % "compile",
+        "org.scalikejdbc"   %% "scalikejdbc"               % scalikejdbcVersion  % "provided",
+        "org.scalikejdbc"   %% "scalikejdbc-config"        % scalikejdbcVersion  % "provided",
         "com.typesafe.play" %%  "play"                     % _defaultPlayVersion % "provided",
         // play-jdbc is needed to test with DBPlugin
         "com.typesafe.play" %% "play-jdbc"                 % _defaultPlayVersion % "test",
@@ -67,8 +68,8 @@ object ScalikeJDBCPlaySupportProjects extends Build {
     baseSettings ++ Seq(
       name := "scalikejdbc-play-dbplugin-adapter",
       libraryDependencies ++= Seq(
-        "org.scalikejdbc"   %% "scalikejdbc"               % scalikejdbcVersion  % "compile",
-        "org.scalikejdbc"   %% "scalikejdbc-config"        % scalikejdbcVersion  % "compile",
+        "org.scalikejdbc"   %% "scalikejdbc"               % scalikejdbcVersion  % "provided",
+        "org.scalikejdbc"   %% "scalikejdbc-config"        % scalikejdbcVersion  % "provided",
         "com.typesafe.play" %% "play"                      % _defaultPlayVersion % "provided",
         "com.typesafe.play" %% "play-jdbc"                 % _defaultPlayVersion % "compile",
         "com.typesafe.play" %% "play-test"                 % _defaultPlayVersion % "test",
@@ -85,7 +86,8 @@ object ScalikeJDBCPlaySupportProjects extends Build {
     baseSettings ++ Seq(
       name := "scalikejdbc-play-fixture-plugin",
       libraryDependencies ++= Seq(
-        "org.scalikejdbc"   %% "scalikejdbc"               % scalikejdbcVersion  % "compile",
+        "org.scalikejdbc"   %% "scalikejdbc"               % scalikejdbcVersion  % "provided",
+        "org.scalikejdbc"   %% "scalikejdbc-config"        % scalikejdbcVersion  % "provided",
         "com.typesafe.play" %% "play"                      % _defaultPlayVersion % "provided",
         "com.typesafe.play" %% "play-test"                 % _defaultPlayVersion % "test",
         "com.h2database"    %  "h2"                        % _h2Version          % "test"
@@ -99,8 +101,9 @@ object ScalikeJDBCPlaySupportProjects extends Build {
     val appName         = "play-plugin-test-zentasks"
 
     val appDependencies = Seq(
-      "org.scalikejdbc"      %% "scalikejdbc"               % scalikejdbcVersion,
-      "org.scalikejdbc"      %% "scalikejdbc-interpolation" % scalikejdbcVersion,
+      "org.scalikejdbc"      %% "scalikejdbc"               % latestScalikejdbcVersion,
+      "org.scalikejdbc"      %% "scalikejdbc-config"        % latestScalikejdbcVersion,
+      "org.scalikejdbc"      %% "scalikejdbc-interpolation" % latestScalikejdbcVersion,
       "com.github.tototoshi" %% "play-flyway" % "1.1.3",
       "com.h2database"       %  "h2"          % _h2Version,
       "org.postgresql"       %  "postgresql"  % "9.3-1102-jdbc41"
@@ -119,8 +122,9 @@ object ScalikeJDBCPlaySupportProjects extends Build {
     val appName         = "play-dbplugin-adapter-test-zentasks"
 
     val appDependencies = Seq(
-      "org.scalikejdbc"      %% "scalikejdbc"               % scalikejdbcVersion,
-      "org.scalikejdbc"      %% "scalikejdbc-interpolation" % scalikejdbcVersion,
+      "org.scalikejdbc"      %% "scalikejdbc"               % latestScalikejdbcVersion,
+      "org.scalikejdbc"      %% "scalikejdbc-config"        % latestScalikejdbcVersion,
+      "org.scalikejdbc"      %% "scalikejdbc-interpolation" % latestScalikejdbcVersion,
       "com.h2database"       %  "h2"          % _h2Version,
       "org.postgresql"       %  "postgresql"  % "9.3-1102-jdbc41"
     )


### PR DESCRIPTION
When using scalikejdbc-play-plugin 2.3.4 with scalikejdbc 2.2.2, java.lang.NoSuchMethodError is thrown.

all trace

```
Caused by: java.lang.NoSuchMethodError: scalikejdbc.ConnectionPoolSettings.<init>(IIJLjava/lang/String;Ljava/lang/String;)V
        at scalikejdbc.config.TypesafeConfigReader$class.readConnectionPoolSettings(TypesafeConfigReader.scala:90) ~[scalikejdbc-config_2.11-2.2.0.jar:2.2.0]
        at scalikejdbc.PlayPlugin$$anon$1.readConnectionPoolSettings(PlayPlugin.scala:37) ~[scalikejdbc-play-plugin_2.11-2.3.4.jar:2.3.4]
        at scalikejdbc.config.DBs$class.setup(DBs.scala:27) ~[scalikejdbc-config_2.11-2.2.0.jar:2.2.0]
        at scalikejdbc.PlayPlugin$$anon$1.setup(PlayPlugin.scala:37) ~[scalikejdbc-play-plugin_2.11-2.3.4.jar:2.3.4]
        at scalikejdbc.config.DBs$$anonfun$setupAll$1.apply(DBs.scala:34) ~[scalikejdbc-config_2.11-2.2.0.jar:2.2.0]
        at scalikejdbc.config.DBs$$anonfun$setupAll$1.apply(DBs.scala:34) ~[scalikejdbc-config_2.11-2.2.0.jar:2.2.0]
        at scala.collection.immutable.List.foreach(List.scala:381) ~[scala-library-2.11.5.jar:na]
        at scalikejdbc.config.DBs$class.setupAll(DBs.scala:34) ~[scalikejdbc-config_2.11-2.2.0.jar:2.2.0]
        at scalikejdbc.PlayPlugin$$anon$1.setupAll(PlayPlugin.scala:37) ~[scalikejdbc-play-plugin_2.11-2.3.4.jar:2.3.4]
        at scalikejdbc.PlayPlugin.onStart(PlayPlugin.scala:42) ~[scalikejdbc-play-plugin_2.11-2.3.4.jar:2.3.4]
        at play.api.Play$$anonfun$start$1$$anonfun$apply$mcV$sp$1.apply(Play.scala:91) ~[play_2.11-2.3.6.jar:2.3.6]
        at play.api.Play$$anonfun$start$1$$anonfun$apply$mcV$sp$1.apply(Play.scala:91) ~[play_2.11-2.3.6.jar:2.3.6]
        at scala.collection.immutable.List.foreach(List.scala:381) ~[scala-library-2.11.5.jar:na]
        at play.api.Play$$anonfun$start$1.apply$mcV$sp(Play.scala:91) ~[play_2.11-2.3.6.jar:2.3.6]
```

At build.sbt

```scala
      "org.scalikejdbc"              %% "scalikejdbc"                      % "2.2.2",
      "org.scalikejdbc"              %% "scalikejdbc-play-plugin"          % "2.3.4",
      "org.scalikejdbc"              %% "scalikejdbc-play-fixture-plugin"  % "2.3.4",
```

It is resolved as follows 

```scala
      "org.scalikejdbc"              %% "scalikejdbc"                      % "2.2.2",
      "org.scalikejdbc"              %% "scalikejdbc-config"               % "2.2.2",
      "org.scalikejdbc"              %% "scalikejdbc-play-plugin"          % "2.3.4",,
      "org.scalikejdbc"              %% "scalikejdbc-play-fixture-plugin"  % "2.3.4",

```
