### PR TITLE
Added ActionBuilders

### DIFF
--- a/scalikejdbc-play-plugin/src/main/scala/scalikejdbc/DBActionBuilders.scala
+++ b/scalikejdbc-play-plugin/src/main/scala/scalikejdbc/DBActionBuilders.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2015 scalikejdbc.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package scalikejdbc
+
+import play.api.mvc.{ Action, ActionBuilder }
+
+trait DBActionBuilders {
+
+  protected implicit lazy val connectionPoolContext: ConnectionPoolContext = NoConnectionPoolContext
+
+  def NamedDBAction(name: Any): ActionBuilder[DBSessionRequest] = Action.andThen(new DBActionFunction(name))
+
+  lazy val DBAction: ActionBuilder[DBSessionRequest] = NamedDBAction('default)
+
+  def NamedDBTxAction(name: Any): ActionBuilder[DBSessionRequest] = Action.andThen(new DBTxActionFunction(name))
+
+  lazy val DBTxAction: ActionBuilder[DBSessionRequest] = NamedDBTxAction('default)
+
+}
+
+object DBActionBuilders extends DBActionBuilders

--- a/scalikejdbc-play-plugin/src/main/scala/scalikejdbc/DBActionFunction.scala
+++ b/scalikejdbc-play-plugin/src/main/scala/scalikejdbc/DBActionFunction.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2015 scalikejdbc.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package scalikejdbc
+
+import play.api.mvc._
+import scala.concurrent.Future
+
+class DBActionFunction(name: Any = 'default)(implicit context: ConnectionPoolContext = NoConnectionPoolContext) extends ActionFunction[Request, DBSessionRequest] {
+
+  def invokeBlock[A](request: Request[A], block: DBSessionRequest[A] => Future[Result]) = {
+    NamedDB(name).autoCommit { session =>
+      block(DBSessionRequest[A](session, request))
+    }
+  }
+
+}

--- a/scalikejdbc-play-plugin/src/main/scala/scalikejdbc/DBSessionRequest.scala
+++ b/scalikejdbc-play-plugin/src/main/scala/scalikejdbc/DBSessionRequest.scala
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2015 scalikejdbc.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package scalikejdbc
+
+import play.api.mvc.{ Request, WrappedRequest }
+
+case class DBSessionRequest[A](dbSession: DBSession, private val request: Request[A]) extends WrappedRequest[A](request)

--- a/scalikejdbc-play-plugin/src/main/scala/scalikejdbc/DBTxActionFunction.scala
+++ b/scalikejdbc-play-plugin/src/main/scala/scalikejdbc/DBTxActionFunction.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2015 scalikejdbc.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package scalikejdbc
+
+import play.api.mvc._
+import scala.concurrent.Future
+
+class DBTxActionFunction(name: Any = 'default)(implicit context: ConnectionPoolContext = NoConnectionPoolContext) extends ActionFunction[Request, DBSessionRequest] {
+
+  def invokeBlock[A](request: Request[A], block: DBSessionRequest[A] => Future[Result]) = {
+    import TxBoundary.Future._
+    NamedDB(name).localTx { session =>
+      block(DBSessionRequest[A](session, request))
+    }
+  }
+
+}

--- a/scalikejdbc-play-plugin/src/test/scala/scalikejdbc/DBActionBuildersSpec.scala
+++ b/scalikejdbc-play-plugin/src/test/scala/scalikejdbc/DBActionBuildersSpec.scala
@@ -1,0 +1,167 @@
+package scalikejdbc
+
+import scalikejdbc._
+
+import org.specs2.mutable.Specification
+
+import play.api._
+import play.api.mvc._
+import play.api.test._
+import play.api.test.Helpers._
+import play.api.Play.current
+
+import DBActionBuilders._
+
+object DBActionBuildersSpec extends Specification with Results {
+
+  sequential
+
+  Class.forName("org.h2.Driver")
+
+  def fakeApp = FakeApplication(
+    withoutPlugins = Seq("play.api.cache.EhCachePlugin"),
+    additionalPlugins = Seq("scalikejdbc.PlayPlugin"),
+    additionalConfiguration = Map(
+      "logger.root" -> "INFO",
+      "logger.play" -> "INFO",
+      "logger.application" -> "DEBUG",
+      "dbplugin" -> "disabled",
+      "evolutionplugin" -> "disabled",
+      "db.default.driver" -> "org.h2.Driver",
+      "db.default.url" -> "jdbc:h2:mem:default",
+      "db.default.user" -> "sa",
+      "db.default.password" -> "sa",
+      "db.default.schema" -> "",
+      "db.default.poolInitialSize" -> "1",
+      "db.default.poolMaxSize" -> "2",
+      "db.default.poolValidationQuery" -> "select 1",
+      "db.default.poolConnectionTimeoutMillis" -> "2000",
+      "db.legacydb.driver" -> "org.h2.Driver",
+      "db.legacydb.url" -> "jdbc:h2:mem:legacy",
+      "db.legacydb.user" -> "l",
+      "db.legacydb.password" -> "g",
+      "db.legacydb.schema" -> "",
+      "scalikejdbc.global.loggingSQLAndTime.enabled" -> "true",
+      "scalikejdbc.global.loggingSQLAndTime.singleLineMode" -> "true",
+      "scalikejdbc.global.loggingSQLAndTime.logLevel" -> "debug",
+      "scalikejdbc.global.loggingSQLAndTime.warningEnabled" -> "true",
+      "scalikejdbc.global.loggingSQLAndTime.warningThreasholdMillis" -> "1",
+      "scalikejdbc.global.loggingSQLAndTime.warningLogLevel" -> "warn"
+    )
+  )
+
+  def fakeAppWithoutCloseAllOnStop = FakeApplication(
+    withoutPlugins = Seq("play.api.cache.EhCachePlugin"),
+    additionalPlugins = Seq("scalikejdbc.PlayPlugin"),
+    additionalConfiguration = Map(
+      "db.default.driver" -> "org.h2.Driver",
+      "db.default.url" -> "jdbc:h2:mem:default",
+      "db.default.user" -> "sa",
+      "db.default.password" -> "sa",
+      "db.legacydb.driver" -> "org.h2.Driver",
+      "db.legacydb.url" -> "jdbc:h2:mem:legacy",
+      "db.legacydb.user" -> "l",
+      "db.legacydb.password" -> "g",
+      "scalikejdbc.play.closeAllOnStop.enabled" -> "false"
+    )
+  )
+
+  def fakeAppWithDBPlugin = FakeApplication(
+    withoutPlugins = Seq("play.api.cache.EhCachePlugin"),
+    additionalPlugins = Seq("scalikejdbc.PlayPlugin"),
+    additionalConfiguration = Map(
+      "db.default.driver" -> "org.h2.Driver",
+      "db.default.url" -> "jdbc:h2:mem:default",
+      "db.default.user" -> "sa",
+      "db.default.password" -> "sa",
+      "db.default.schema" -> "",
+      "db.legacydb.driver" -> "org.h2.Driver",
+      "db.legacydb.url" -> "jdbc:h2:mem:legacy",
+      "db.legacydb.user" -> "l",
+      "db.legacydb.password" -> "g",
+      "db.legacydb.schema" -> "",
+      "scalikejdbc.global.loggingSQLAndTime.enabled" -> "true",
+      "scalikejdbc.global.loggingSQLAndTime.logLevel" -> "debug",
+      "scalikejdbc.global.loggingSQLAndTime.warningEnabled" -> "true",
+      "scalikejdbc.global.loggingSQLAndTime.warningThreasholdMillis" -> "1",
+      "scalikejdbc.global.loggingSQLAndTime.warningLogLevel" -> "warn"
+    )
+  )
+
+  "DBActionBuilders" should {
+
+    "create DBAction" in {
+      running(fakeApp) {
+        val action = DBAction { req =>
+          implicit val session = req.dbSession
+          SQL("DROP TABLE user_action_1 IF EXISTS").execute.apply()
+          SQL("CREATE TABLE user_action_1 (ID BIGINT PRIMARY KEY NOT NULL, NAME VARCHAR(256))").execute.apply()
+          val insert = SQL("INSERT INTO user_action_1 (ID, NAME) VALUES (/*'id*/123, /*'name*/'Alice')")
+          insert.bindByName('id -> 1, 'name -> "Alice").update.apply()
+          insert.bindByName('id -> 2, 'name -> "Bob").update.apply()
+          insert.bindByName('id -> 3, 'name -> "Eve").update.apply()
+          val name = SQL("SELECT name FROM user_action_1 WHERE id = 1").map(_.string(1)).single.apply()
+          Ok(name.toString)
+        }
+        val result = action(FakeRequest())
+        contentAsString(result) must_== ("Some(Alice)")
+      }
+    }
+
+    "create NamedDBAction" in {
+      running(fakeApp) {
+        val action = NamedDBAction('legacydb) { req =>
+          implicit val session = req.dbSession
+          SQL("DROP TABLE user_action_2 IF EXISTS").execute.apply()
+          SQL("CREATE TABLE user_action_2 (ID BIGINT PRIMARY KEY NOT NULL, NAME VARCHAR(256))").execute.apply()
+          val insert = SQL("INSERT INTO user_action_2 (ID, NAME) VALUES (/*'id*/123, /*'name*/'Alice')")
+          insert.bindByName('id -> 1, 'name -> "Alice").update.apply()
+          insert.bindByName('id -> 2, 'name -> "Bob").update.apply()
+          insert.bindByName('id -> 3, 'name -> "Eve").update.apply()
+          val name = SQL("SELECT name FROM user_action_2 WHERE id = 2").map(_.string(1)).single.apply()
+          Ok(name.toString)
+        }
+        val result = action(FakeRequest())
+        contentAsString(result) must_== ("Some(Bob)")
+      }
+    }
+
+    "create DBTxAction" in {
+      running(fakeApp) {
+        val action = DBTxAction { req =>
+          implicit val session = req.dbSession
+          SQL("DROP TABLE user_action_3 IF EXISTS").execute.apply()
+          SQL("CREATE TABLE user_action_3 (ID BIGINT PRIMARY KEY NOT NULL, NAME VARCHAR(256))").execute.apply()
+          val insert = SQL("INSERT INTO user_action_3 (ID, NAME) VALUES (/*'id*/123, /*'name*/'Alice')")
+          insert.bindByName('id -> 1, 'name -> "Alice").update.apply()
+          insert.bindByName('id -> 2, 'name -> "Bob").update.apply()
+          insert.bindByName('id -> 3, 'name -> "Eve").update.apply()
+          val name = SQL("SELECT name FROM user_action_3 WHERE id = 1").map(_.string(1)).single.apply()
+          Ok(name.toString)
+        }
+        val result = action(FakeRequest())
+        contentAsString(result) must_== ("Some(Alice)")
+      }
+    }
+
+    "create NamedDBTxAction" in {
+      running(fakeApp) {
+        val action = NamedDBTxAction('legacydb) { req =>
+          implicit val session = req.dbSession
+          SQL("DROP TABLE user_action_4 IF EXISTS").execute.apply()
+          SQL("CREATE TABLE user_action_4 (ID BIGINT PRIMARY KEY NOT NULL, NAME VARCHAR(256))").execute.apply()
+          val insert = SQL("INSERT INTO user_action_4 (ID, NAME) VALUES (/*'id*/123, /*'name*/'Alice')")
+          insert.bindByName('id -> 1, 'name -> "Alice").update.apply()
+          insert.bindByName('id -> 2, 'name -> "Bob").update.apply()
+          insert.bindByName('id -> 3, 'name -> "Eve").update.apply()
+          val name = SQL("SELECT name FROM user_action_4 WHERE id = 2").map(_.string(1)).single.apply()
+          Ok(name.toString)
+        }
+        val result = action(FakeRequest())
+        contentAsString(result) must_== ("Some(Bob)")
+      }
+    }
+
+  }
+
+}


### PR DESCRIPTION
Created ActionBuilders that provides DBSession as Action

We can write like follows

```scala
import scalikejdbc.DBActionBuilders._

object FooController extends Controller {
  
  def index = DBAction { request =>
    implicit val session = request.dbSession
    sql"SELECT ....".map(_.int(1)).list().apply()
    ...
  }

}


```