### PR TITLE
Ensure scalikejdbc fixture run after initializer

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -85,7 +85,7 @@ object ScalikeJDBCPlaySupportProjects extends Build {
       ),
       testOptions in Test += Tests.Argument(TestFrameworks.Specs2, "sequential", "true")
     ) : _*
-  ).dependsOn(scalikejdbcPlayInitializer % "test->test")
+  ).dependsOn(scalikejdbcPlayInitializer)
 
   // play plugin zentasks example
   lazy val scalikejdbcPlayInitializerTestZentasks = {

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -78,6 +78,7 @@ object ScalikeJDBCPlaySupportProjects extends Build {
       name := "scalikejdbc-play-fixture",
       libraryDependencies ++= Seq(
         "org.scalikejdbc"   %% "scalikejdbc"        % scalikejdbcVersion  % "provided",
+        "org.scalikejdbc"   %% "scalikejdbc-config" % scalikejdbcVersion  % "provided",
         "com.typesafe.play" %% "play"               % defaultPlayVersion  % "provided",
         "com.typesafe.play" %% "play-test"          % defaultPlayVersion  % "test",
         "com.h2database"    %  "h2"                 % h2Version           % "test"

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -80,7 +80,6 @@ object ScalikeJDBCPlaySupportProjects extends Build {
         "org.scalikejdbc"   %% "scalikejdbc"        % scalikejdbcVersion  % "provided",
         "com.typesafe.play" %% "play"               % defaultPlayVersion  % "provided",
         "com.typesafe.play" %% "play-test"          % defaultPlayVersion  % "test",
-        "org.scalikejdbc"   %% "scalikejdbc-config" % scalikejdbcVersion  % "test",
         "com.h2database"    %  "h2"                 % h2Version           % "test"
       ),
       testOptions in Test += Tests.Argument(TestFrameworks.Specs2, "sequential", "true")

--- a/scalikejdbc-play-fixture/src/main/scala/scalikejdbc/PlayFixtureModule.scala
+++ b/scalikejdbc-play-fixture/src/main/scala/scalikejdbc/PlayFixtureModule.scala
@@ -25,6 +25,7 @@ import scala.concurrent.Future
  */
 class PlayFixtureModule extends Module {
   def bindings(env: Environment, config: Configuration) = Seq(
+    bind[PlayInitializer].toSelf.eagerly,
     bind[PlayFixture].toSelf.eagerly
   )
 }
@@ -35,6 +36,7 @@ class PlayFixtureModule extends Module {
 @Singleton
 class PlayFixture @Inject() (
   implicit app: Application,
+  playInitializer: PlayInitializer,
   lifecycle: ApplicationLifecycle)
     extends scalikejdbc.play.FixtureSupport {
 

--- a/scalikejdbc-play-fixture/src/main/scala/scalikejdbc/PlayFixtureModule.scala
+++ b/scalikejdbc-play-fixture/src/main/scala/scalikejdbc/PlayFixtureModule.scala
@@ -35,20 +35,25 @@ class PlayFixtureModule extends Module {
  */
 @Singleton
 class PlayFixture @Inject() (
-  implicit app: Application,
+  configuration: Configuration,
+  environment: Environment,
   playInitializer: PlayInitializer,
   lifecycle: ApplicationLifecycle)
     extends scalikejdbc.play.FixtureSupport {
 
+  private def isTest = environment.mode == Mode.Test
+
+  private def isDev = environment.mode == Mode.Dev
+
   def onStart(): Unit = {
-    if (Play.isTest || Play.isDev) {
-      loadFixtures()
+    if (isTest || isDev) {
+      loadFixtures()(environment, configuration)
     }
   }
 
   def onStop(): Unit = {
-    if (Play.isTest || Play.isDev) {
-      cleanFixtures()
+    if (isTest || isDev) {
+      cleanFixtures()(environment, configuration)
     }
   }
 

--- a/scalikejdbc-play-fixture/src/main/scala/scalikejdbc/PlayFixtureModule.scala
+++ b/scalikejdbc-play-fixture/src/main/scala/scalikejdbc/PlayFixtureModule.scala
@@ -32,6 +32,7 @@ class PlayFixtureModule extends Module {
 /**
  * The Play fixture plugin
  */
+@Singleton
 class PlayFixture @Inject() (
   implicit app: Application,
   lifecycle: ApplicationLifecycle)

--- a/scalikejdbc-play-fixture/src/test/scala/scalikejdbc/play/FixtureSupportSpec.scala
+++ b/scalikejdbc-play-fixture/src/test/scala/scalikejdbc/play/FixtureSupportSpec.scala
@@ -1,10 +1,9 @@
 package scalikejdbc.play
 
-import play.api.test._
-import play.api.test.Helpers._
 import org.specs2.mutable._
 import org.specs2.specification.BeforeAfterEach
-import play.api.Play.current
+import play.api.{ Configuration, Environment }
+
 import scala.collection.JavaConverters._
 
 class FixtureSupportSpec extends Specification with BeforeAfterEach {
@@ -17,32 +16,28 @@ class FixtureSupportSpec extends Specification with BeforeAfterEach {
 
   val fixtureSupport = new FixtureSupport {}
 
-  def fakeApp = FakeApplication(
-    additionalConfiguration = Map(
-      "play.modules.enabled" -> List(
-        "scalikejdbc.PlayModule",
-        "scalikejdbc.PlayFixtureModule",
-        "play.api.inject.BuiltinModule"
-      ),
-      "db.default.fixtures.test" -> List("users.sql", "project.sql").asJava,
-      "db.secondary.fixtures.test" -> "a.sql",
-      "db.default.driver" -> "org.h2.Driver",
-      "db.default.url" -> "jdbc:h2:mem:default;DB_CLOSE_DELAY=-1",
-      "db.default.user" -> "sa",
-      "db.default.password" -> "sa",
-      "db.secondary.driver" -> "org.h2.Driver",
-      "db.secondary.url" -> "jdbc:h2:mem:secondary;DB_CLOSE_DELAY=-1",
-      "db.secondary.user" -> "l",
-      "db.secondary.password" -> "g"
-    )
-  )
-
   "FixtureSupport" should {
 
     "has #fixtures" in {
-      running(fakeApp) {
-        fixtureSupport.fixtures must have size 2
-      }
+      val environment = Environment.simple()
+      val configuration = Configuration(
+        "play.modules.enabled" -> List(
+          "scalikejdbc.PlayModule",
+          "scalikejdbc.PlayFixtureModule",
+          "play.api.inject.BuiltinModule"
+        ),
+        "db.default.fixtures.test" -> List("users.sql", "project.sql").asJava,
+        "db.secondary.fixtures.test" -> "a.sql",
+        "db.default.driver" -> "org.h2.Driver",
+        "db.default.url" -> "jdbc:h2:mem:default;DB_CLOSE_DELAY=-1",
+        "db.default.user" -> "sa",
+        "db.default.password" -> "sa",
+        "db.secondary.driver" -> "org.h2.Driver",
+        "db.secondary.url" -> "jdbc:h2:mem:secondary;DB_CLOSE_DELAY=-1",
+        "db.secondary.user" -> "l",
+        "db.secondary.password" -> "g"
+      )
+      fixtureSupport.fixtures(environment, configuration) must have size 2
     }
 
   }


### PR DESCRIPTION
Guice based module system of Play 2.4 decides the order of loading modules from constructor-based dependecy.
This pull-req ensures that scalikejdbc-fixture run after scalikejdbc-play-initializer.
Without this, scalikejdbc-fixture may run before the connection pool is initialized.