### PR TITLE
Clear loaded columns on stop

### DIFF
--- a/scalikejdbc-play-dbapi-adapter/src/main/scala/scalikejdbc/PlayDBApiAdapter.scala
+++ b/scalikejdbc-play-dbapi-adapter/src/main/scala/scalikejdbc/PlayDBApiAdapter.scala
@@ -20,6 +20,7 @@ import play.api._
 import play.api.inject._
 import play.api.db.{ DBApi, DBApiProvider, BoneConnectionPool }
 import scalikejdbc.config.{ TypesafeConfig, TypesafeConfigReader, DBs }
+import scala.concurrent.Future
 
 /**
  * The Play plugin to use ScalikeJDBC
@@ -49,5 +50,11 @@ class PlayDBApiAdapter @Inject() (
     }
   }
 
+  def onStop(): Unit = {
+    val cache = SQLSyntaxSupportFeature.SQLSyntaxSupportLoadedColumns
+    cache.clear()
+  }
+
+  lifecycle.addStopHook(() => Future.successful(onStop))
   onStart()
 }

--- a/scalikejdbc-play-initializer/src/main/scala/scalikejdbc/PlayInitializer.scala
+++ b/scalikejdbc-play-initializer/src/main/scala/scalikejdbc/PlayInitializer.scala
@@ -53,6 +53,9 @@ class PlayInitializer @Inject() (
     if (closeAllOnStop) {
       ConnectionPool.closeAll()
     }
+
+    val cache = SQLSyntaxSupportFeature.SQLSyntaxSupportLoadedColumns
+    cache.clear()
   }
 
   lifecycle.addStopHook(() => Future.successful(onStop))


### PR DESCRIPTION
ScalikeJDBC has cache for columns using `SQLSyntaxSupportFeature`.
When we do Play evolutions on dev mode, added/renamed/removed columns are not cleared from cache.
The behavior brings `SQLException` because ScalikeJDBC refers old column information.

This PR will clear the cache when Play stops application.