### PR TITLE
Set loggingSQLErrors in DB Api adapter

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -51,6 +51,7 @@ db.default.password=sa
 #db.default.poolMaxSize=10
 #db.default.poolValidationQuery=
 
+scalikejdbc.global.loggingSQLErrors=true
 scalikejdbc.global.loggingSQLAndTime.enabled=true
 scalikejdbc.global.loggingSQLAndTime.singleLineMode=false
 scalikejdbc.global.loggingSQLAndTime.logLevel=debug

--- a/scalikejdbc-play-dbapi-adapter/src/main/scala/scalikejdbc/PlayDBApiAdapter.scala
+++ b/scalikejdbc-play-dbapi-adapter/src/main/scala/scalikejdbc/PlayDBApiAdapter.scala
@@ -38,8 +38,11 @@ class PlayDBApiAdapter @Inject() (
     override val config = configuration.underlying
   }
 
+  private[this] lazy val loggingSQLErrors = configuration.getBoolean("scalikejdbc.global.loggingSQLErrors").getOrElse(true)
+
   def onStart(): Unit = {
     DBs.loadGlobalSettings()
+    GlobalSettings.loggingSQLErrors = loggingSQLErrors
 
     dbApi.databases.foreach { db =>
       scalikejdbc.ConnectionPool.add(Symbol(db.name), new DataSourceConnectionPool(db.dataSource))


### PR DESCRIPTION
Read `scalikejdbc.global.loggingSQLErrors` from configuration and on `GlobalSettings`.