### PR TITLE
Support loggingSQLErrors in Play initializer

### DIFF
--- a/scalikejdbc-play-initializer/src/main/scala/scalikejdbc/PlayInitializer.scala
+++ b/scalikejdbc-play-initializer/src/main/scala/scalikejdbc/PlayInitializer.scala
@@ -38,6 +38,8 @@ class PlayInitializer @Inject() (
 
   private[this] var closeAllOnStop = true
 
+  private[this] lazy val loggingSQLErrors = configuration.getBoolean("scalikejdbc.global.loggingSQLErrors").getOrElse(true)
+
   /**
    * DBs with Play application configuration.
    */
@@ -47,6 +49,7 @@ class PlayInitializer @Inject() (
 
   def onStart(): Unit = {
     DBs.setupAll()
+    GlobalSettings.loggingSQLErrors = loggingSQLErrors
     opt("closeAllOnStop", "enabled")(playConfig).foreach { enabled => closeAllOnStop = enabled.toBoolean }
   }
 


### PR DESCRIPTION
In last pull request I added support for `loggingSQLErrors` in DB Api adapter, but forgot about the Play initializer. So, this commit adds support to the latter as well.

Would be nice if you could make another release soon.