### PR TITLE
add Encoding when it reads fixture

### DIFF
--- a/scalikejdbc-play-fixture/src/main/scala/scalikejdbc/play/Fixture.scala
+++ b/scalikejdbc-play-fixture/src/main/scala/scalikejdbc/play/Fixture.scala
@@ -16,11 +16,12 @@
 package scalikejdbc.play
 
 import scala.io.Source
+import scala.io.Codec
 import java.io.File
 
 case class Fixture(file: File) {
 
-  private def script: String = Source.fromFile(file).mkString
+  private def script: String = Source.fromFile(file)(Codec.UTF8).mkString
 
   private def isUpsMarker(s: String): Boolean = s.matches("""^#.*!Ups.*$""")
 


### PR DESCRIPTION
On Japanese Windows, and Using Japanese in fixtures file(UTF-8N), PlayFixture throws an MalformedInputException.

We don't expect that other encoding are used in fixtures file.