### PR TITLE
Upgrade to Play Framework 2.9.0-RC2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-java@v3
       with:
-        java-version: 8
+        java-version: 11
         distribution: temurin
     - uses: coursier/cache-action@v6
     - shell: bash

--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ lazy val postgresqlVersion = "42.6.0"
 
 lazy val commonSettings = Seq(
   scalaVersion := "2.13.12",
-  crossScalaVersions := Seq("2.12.18", "2.13.12", "3.3.1"),
+  crossScalaVersions := Seq("2.13.12", "3.3.1"),
   libraryDependencySchemes += "org.scala-lang.modules" %% "scala-parser-combinators" % "always",
   Test / fork := true,
   javaOptions ++= {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.19")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.0-RC2")
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.2.1")
 
 scalacOptions ++= Seq("-deprecation", "-unchecked", "-language:_")


### PR DESCRIPTION
We can try Play Framework 2.9.
https://github.com/playframework/playframework/releases/tag/2.9.0-RC2

Scala 2.12 and Java 8 support has been dropped since Play Framework 2.9.
See more details [Scala 2.12, sbt 0.13 and Java 8 Support discontinued](https://www.playframework.com/documentation/2.9.x/Highlights29#Scala-2.12,-sbt-0.13-and-Java-8-Support-discontinued).